### PR TITLE
development of device index from configuration file for rtlsdr and mirics

### DIFF
--- a/common/constants.cpp
+++ b/common/constants.cpp
@@ -69,6 +69,14 @@ GlobalConfig::GlobalConfig() {
         settings.setValue("RF_GAIN", (int)RF_NO_GAIN );
     }
 
+    device_index = 0 ;
+    if (settings.contains("DEVICE_INDEX")) {
+      device_index = settings.value("DEVICE_INDEX").toInt();
+    }
+    else {
+      settings.setValue("DEVICE_INDEX", 0);
+    }
+
     threshold = 0 ;
     if( settings.contains("THRESHOLD")) {
         threshold = settings.value("THRESHOLD").toInt();

--- a/common/constants.h
+++ b/common/constants.h
@@ -100,6 +100,7 @@ public:
     int ppm_error ;
     int threshold ;
     int rf_gain ;
+    int device_index ;
     int fft_rate ;
     QString cFIFO_FileName ;
     qint64 cRX_FREQUENCY ;

--- a/hardware/rxhardwareselector.cpp
+++ b/hardware/rxhardwareselector.cpp
@@ -44,13 +44,15 @@ RxDevice *RxHardwareSelector::getReceiver() {
     MiricsSDR *rsp = NULL ;
     AirspyDevice *spy = NULL ;
 
+    GlobalConfig& cnf = GlobalConfig::getInstance() ;
+
     spy = new AirspyDevice();
     if( spy->getDeviceCount() > 0 ) {
         return(spy);
     }
     delete spy ;
 
-    rsp = new MiricsSDR(0);
+    rsp = new MiricsSDR(cnf.device_index);
     if( rsp->getDeviceCount() > 0 ) {
         rsp->setRxSampleRate(1536*1000);
         return( rsp );
@@ -75,7 +77,7 @@ Is there is a bug with the FUNCUBE implementation ?
     delete fcdboard ;
     fcdboard = NULL ;
 
-    dongle = new RTLSDR(0);
+    dongle = new RTLSDR(cnf.device_index);
     if( dongle->getDeviceCount() > 0 ) {
         if( dongle->setRxSampleRate( SYMBOL_RATE * 100 ) == 0 ) { // sampling rate is .960 MHz
             return(dongle);


### PR DESCRIPTION
When using multiple device of the same kind, the device index can be specified by using DEVICE_INDEX=<i> in the RADIO section of the pictalk.conf file.
It has been tested successfully for the rtlsdr and should work for the mirics.