### PR TITLE
adds SatNogs SIDS upload of decoded packets

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -379,7 +379,7 @@ void MainWindow::uploadFrame( QString frame ) {
 }
 
 void MainWindow::uploadSatnogs( QString frame ) {
-    // https://db-dev.satnogs.org/api/telemetry/ -or- https://db.satnogs.org/api/telemetry/
+    // https://db.satnogs.org/api/telemetry/
     GlobalConfig& gc = GlobalConfig::getInstance() ;
     if( "NOSIDS" == gc.CALLSIGN) {
         // specific call to disable SiDS transmit

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -378,6 +378,32 @@ void MainWindow::uploadFrame( QString frame ) {
     networkManager->post(request, sids.toString(QUrl::FullyEncoded).toUtf8());
 }
 
+void MainWindow::uploadSatnogs( QString frame ) {
+    // https://db-dev.satnogs.org/api/telemetry/ -or- https://db.satnogs.org/api/telemetry/
+    GlobalConfig& gc = GlobalConfig::getInstance() ;
+    if( "NOSIDS" == gc.CALLSIGN) {
+        // specific call to disable SiDS transmit
+        return ;
+    }
+
+    QUrlQuery sids;
+    sids.addQueryItem("noradID", "43132");
+    sids.addQueryItem("source", gc.CALLSIGN);
+    QDateTime now = QDateTime::currentDateTime().toUTC() ;
+    sids.addQueryItem("timestamp", now.toString(Qt::ISODate) );
+    sids.addQueryItem("locator", "latlong");
+    sids.addQueryItem("longitude",  gc.mLongitude );
+    sids.addQueryItem("latitude", gc.mLatitude );
+    sids.addQueryItem("frame", frame.remove(' '));
+    sids.addQueryItem("satnogs_network", "False");
+    sids.addQueryItem("observation_id", "");
+    sids.addQueryItem("station_id", "");
+    QNetworkRequest request( QUrl("https://db.satnogs.org/api/telemetry/"));
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+
+    networkManager->post(request, sids.toString(QUrl::FullyEncoded).toUtf8());
+}
+
 
 void MainWindow::sidsSubmitted(QNetworkReply *rep) {
     if( rep->error() == QNetworkReply::NoError ) {
@@ -409,6 +435,7 @@ void MainWindow::PythonFrame( QString frame ) {
     out << frame << "\n" ;
     file.close();
 
+    uploadSatnogs(frame);
     uploadFrame(frame);
 
     pythonText->moveCursor (QTextCursor::End);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -124,6 +124,7 @@ private:
 
     QNetworkAccessManager *networkManager ;
     void uploadFrame( QString frame );
+    void uploadSatnogs( QString frame );
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
With adjustments to meet the **SatNogs SIDS** format, have duplicated the existing SIDS routine that uploads decodes to the PicSat server.    On the pass just ended 24-June-2022 @ 0358z, uploads to BOTH servers were successful.

Important note:  I do not know how to create or modify the **sidsSubmitted** routine to reflect whether the successful SIDS upload was to PicSat or SatNogs.  So, you may wish to make the necessary changes.   As written, my 'Decoder' tab shows -2- confirmations... one for the PicSat Server upload and one for the SatNogs upload.  However, of course they use the same text:

```
>Checked Data from b'PICSATpPICSAT2' -> cat 1
Frame: {
a0 92 86 a6 82 a8 e0 a0 92 86 a6 82 a8 65 03 f0 09 01 f0 1d 00 6c 2a e3 01 21 3e d1 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 db 02 dd 09 7a 06 72 04 48 0d 35 03 be 0a 7c ff f5 ff f5 04 20 91 00 00 00 ff ff 78 00 00 00 00 00 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 51 64 00 04 00 30 89 f0 0a 04 00 02 00 00 00 00 00 
}
Frame is>.............e.......l*..!>......................z.r.H.5......... ......x........................................Qd...0...........
Frame accepted by PicSat server
Frame accepted by PicSat server
```
